### PR TITLE
[Major][BugFix][TestFix] Should only update visitedDate if itemKey already exists, otherwise it won't download as URL itemKey already exists in cachedItemDict.

### DIFF
--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -367,10 +367,12 @@ internal extension CZDiskCacheManager {
     self.ioQueue.async(flags: .barrier) { [weak self] in
       guard let `self` = self else { return }
       removeFileURLs?.forEach {
-        do {
-          try self.fileManager.removeItem(at: $0)
-        } catch {
-          assertionFailure("Failed to remove file. Error - \(error.localizedDescription)")
+        if self.fileManager.fileExists(atPath: $0.absoluteString) {
+          do {
+            try self.fileManager.removeItem(at: $0)
+          } catch {
+            assertionFailure("Failed to remove file \($0). Error - \(error.localizedDescription)")
+          }
         }
       }
       

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -193,7 +193,7 @@ extension CZDiskCacheManager {
   }
   
   /**
-   - Note: Tests Only!
+   - Note: For tests only!
    
    Should call `cachedItemsDictLock.readLock` to read cachedItemsDict for data consistency.
    */

--- a/Tests/CZHttpFileTests/CZHttpFileCacheTests/CZDiskCacheManagerTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileCacheTests/CZDiskCacheManagerTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import CZUtils
+import CZTestUtils
+import CZNetworking
+@testable import CZHttpFile
+
+final class CZDiskCacheManagerTests: XCTestCase {
+  private enum MockData {
+    static let key = "929832737212"
+    static let testUrl = URL(string: "http://www.test.com/some_file.jpg")!
+    static let dict: [String: AnyHashable] = [
+      "a": "sdlfjas",
+      "c": "sdlksdf",
+      "b": "239823sd",
+      "d": 189298723,
+    ]
+  }
+  var httpFileCache: CZHttpFileCache!
+  
+  override func setUp() {
+    httpFileCache = CZHttpFileCache()
+    // httpFileCache.removeCachedItemsDict(forUrl: MockData.testUrl)
+    Thread.sleep(forTimeInterval: 0.01)
+  }
+  
+  /*
+  public enum CacheConstant {
+    public static let kMaxFileAge: TimeInterval = 60 * 24 * 60 * 60
+    public static let kMaxCacheSize: Int = 500 * 1024 * 1024
+    public static let kCachedItemsDictFile = "cachedItemsDict.plist"
+    public static let kFileModifiedDate = "modifiedDate"
+    public static let kFileVisitedDate = "visitedDate"
+    public static let kHttpUrlString = "url"
+    public static let kFileSize = "size"
+    public static let ioQueueLabel = "com.tony.cache.ioQueue"
+  }
+ */
+  
+  func testSetCachedItemsDict() {
+    // setCachedItemsDict.
+    httpFileCache.diskCacheManager.setCachedItemsDict(
+      key: MockData.key,
+      subkey: CacheConstant.kHttpUrlString,
+      value: MockData.testUrl.absoluteString)
+    
+    // Verify: getCachedItemsDict.
+    let cachedItemsDict = httpFileCache.diskCacheManager.getCachedItemsDict()
+    let actualUrl = cachedItemsDict[MockData.key]?[CacheConstant.kHttpUrlString] as? String
+    XCTAssertEqual(
+      actualUrl,
+      MockData.testUrl.absoluteString,
+      "Incorrect url value! expected = \(MockData.testUrl.absoluteString), \nactual = \(actualUrl)"
+    )
+  }
+  
+  
+}

--- a/Tests/CZHttpFileTests/CZHttpFileCacheTests/CZDiskCacheManagerTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileCacheTests/CZDiskCacheManagerTests.swift
@@ -7,6 +7,7 @@ import CZNetworking
 final class CZDiskCacheManagerTests: XCTestCase {
   private enum MockData {
     static let key = "929832737212"
+    static let testSize = 16232
     static let testUrl = URL(string: "http://www.test.com/some_file.jpg")!
     static let dict: [String: AnyHashable] = [
       "a": "sdlfjas",
@@ -17,6 +18,18 @@ final class CZDiskCacheManagerTests: XCTestCase {
   }
   var httpFileCache: CZHttpFileCache!
   
+  override class func setUp() {
+    let httpFileCache = CZHttpFileCache()
+    httpFileCache.clearCache()
+    Thread.sleep(forTimeInterval: 0.1)
+  }
+  
+  override class func tearDown() {
+    let httpFileCache = CZHttpFileCache()
+    httpFileCache.clearCache()
+    Thread.sleep(forTimeInterval: 0.1)
+  }
+  
   override func setUp() {
     httpFileCache = CZHttpFileCache()
     // httpFileCache.removeCachedItemsDict(forUrl: MockData.testUrl)
@@ -25,9 +38,6 @@ final class CZDiskCacheManagerTests: XCTestCase {
   
   /*
   public enum CacheConstant {
-    public static let kMaxFileAge: TimeInterval = 60 * 24 * 60 * 60
-    public static let kMaxCacheSize: Int = 500 * 1024 * 1024
-    public static let kCachedItemsDictFile = "cachedItemsDict.plist"
     public static let kFileModifiedDate = "modifiedDate"
     public static let kFileVisitedDate = "visitedDate"
     public static let kHttpUrlString = "url"
@@ -36,22 +46,32 @@ final class CZDiskCacheManagerTests: XCTestCase {
   }
  */
   
-  func testSetCachedItemsDict() {
+  func testSetCachedItemsDict1() {
     // setCachedItemsDict.
     httpFileCache.diskCacheManager.setCachedItemsDict(
       key: MockData.key,
-      subkey: CacheConstant.kHttpUrlString,
-      value: MockData.testUrl.absoluteString)
+      subkey: CacheConstant.kFileSize,
+      value: MockData.testSize)
     
     // Verify: getCachedItemsDict.
     let cachedItemsDict = httpFileCache.diskCacheManager.getCachedItemsDict()
-    let actualUrl = cachedItemsDict[MockData.key]?[CacheConstant.kHttpUrlString] as? String
+    let actualValue = cachedItemsDict[MockData.key]?[CacheConstant.kFileSize] as? Int
     XCTAssertEqual(
-      actualUrl,
-      MockData.testUrl.absoluteString,
-      "Incorrect url value! expected = \(MockData.testUrl.absoluteString), \nactual = \(actualUrl)"
+      actualValue,
+      MockData.testSize,
+      "Incorrect value! expected = \(MockData.testSize), \nactual = \(actualValue)"
     )
   }
   
+  func testSetCachedItemsDict2_ReadFromCache() {
+    // Verify from cache: getCachedItemsDict.
+    let cachedItemsDict = httpFileCache.diskCacheManager.getCachedItemsDict()
+    let actualValue = cachedItemsDict[MockData.key]?[CacheConstant.kFileSize] as? Int
+    XCTAssertEqual(
+      actualValue,
+      MockData.testSize,
+      "Incorrect value! expected = \(MockData.testSize), \nactual = \(actualValue)"
+    )
+  }
   
 }

--- a/Tests/CZHttpFileTests/CZHttpFileCacheTests/CZDiskCacheManagerTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileCacheTests/CZDiskCacheManagerTests.swift
@@ -36,7 +36,7 @@ final class CZDiskCacheManagerTests: XCTestCase {
   override func setUp() {
     httpFileCache = CZHttpFileCache()
     // httpFileCache.removeCachedItemsDict(forUrl: MockData.testUrl)
-    Thread.sleep(forTimeInterval: 0.01)
+    // Thread.sleep(forTimeInterval: 0.01)
   }
   
   /*

--- a/Tests/CZHttpFileTests/CZHttpFileDownloadTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileDownloadTests.swift
@@ -20,8 +20,13 @@ final class CZHttpFileDownloadTests: XCTestCase {
   private var httpFileManager: CZHttpFileManager!
   
   override class func setUp() {
-    let httpFileManager = CZHttpFileManager()
-    httpFileManager.cache.diskCacheManager.removeCachedItemsDict(forUrl: MockData.urlForGet)
+    let httpFileManager = CZHttpFileManager()    
+    // Should call clearCache() to clear cached files, otherwise it returns the cached file directly
+    // without checking cachedItemDict.
+    httpFileManager.cache.clearCache()
+    // httpFileManager.cache.diskCacheManager.removeCachedItemsDict(forUrl: MockData.urlForGet)
+    
+    Thread.sleep(forTimeInterval: 0.1)
   }
   
   override func setUp() {
@@ -97,6 +102,7 @@ final class CZHttpFileDownloadTests: XCTestCase {
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
       
       // Verify download state.
+      Thread.sleep(forTimeInterval: 0.1)
       let downloadState = self.httpFileManager.downloadState(forURL: MockData.urlForGet)
       XCTAssert(downloadState == .downloaded, "Incorrect downloadState. Actual result = \(downloadState), Expected result = .downloaded")
 

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
@@ -32,6 +32,9 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
   }
   
   func testDownloadFileAndPublishDownloadedURLs() {
+//    CZHttpFileManager.shared.cache.clearCache()
+//    Thread.sleep(forTimeInterval: 1)
+    
     let (waitForExpectatation, expectation) = CZTestUtils.waitWithInterval(Constant.timeOut, testCase: self)
     
     // Create mockDataMap.
@@ -47,15 +50,15 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
     // 2. Download file.
     httpFileManager.downloadFile(url: MockData.urlForGet) { (data: Data?, error: Error?, fromCache: Bool) in
       
-//      // 3. Verify downloadedURLs be published to the observer.
-//      Thread.sleep(forTimeInterval: 1)
-//      let actualDownloadedURLs = self.testDownloadedObserver.downloadedURLs
-//      let expectedDownloadedURLs = [MockData.urlForGet]
-//      XCTAssertTrue(
-//        actualDownloadedURLs == expectedDownloadedURLs,
-//        "publishDownloadedURLs doesn't work correctly. expected = \(expectedDownloadedURLs), \n actual = \(actualDownloadedURLs)")
-//      
-//      expectation.fulfill()
+      // 3. Verify downloadedURLs be published to the observer.
+      Thread.sleep(forTimeInterval: 0.1)
+      let actualDownloadedURLs = self.testDownloadedObserver.downloadedURLs
+      let expectedDownloadedURLs = [MockData.urlForGet]
+      XCTAssertTrue(
+        actualDownloadedURLs == expectedDownloadedURLs,
+        "publishDownloadedURLs doesn't work correctly. expected = \(expectedDownloadedURLs), \n actual = \(actualDownloadedURLs)")
+      
+      expectation.fulfill()
     }
     
     // Wait for expectatation.

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
@@ -47,15 +47,15 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
     // 2. Download file.
     httpFileManager.downloadFile(url: MockData.urlForGet) { (data: Data?, error: Error?, fromCache: Bool) in
       
-      // 3. Verify downloadedURLs be published to the observer.
-      Thread.sleep(forTimeInterval: 0.1)
-      let actualDownloadedURLs = self.testDownloadedObserver.downloadedURLs
-      let expectedDownloadedURLs = [MockData.urlForGet]
-      XCTAssertTrue(
-        actualDownloadedURLs == expectedDownloadedURLs,
-        "publishDownloadedURLs doesn't work correctly. expected = \(expectedDownloadedURLs), \n actual = \(actualDownloadedURLs)")
-      
-      expectation.fulfill()
+//      // 3. Verify downloadedURLs be published to the observer.
+//      Thread.sleep(forTimeInterval: 1)
+//      let actualDownloadedURLs = self.testDownloadedObserver.downloadedURLs
+//      let expectedDownloadedURLs = [MockData.urlForGet]
+//      XCTAssertTrue(
+//        actualDownloadedURLs == expectedDownloadedURLs,
+//        "publishDownloadedURLs doesn't work correctly. expected = \(expectedDownloadedURLs), \n actual = \(actualDownloadedURLs)")
+//      
+//      expectation.fulfill()
     }
     
     // Wait for expectatation.

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
@@ -31,10 +31,7 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
     testDownloadedObserver = TestDownloadedObserver()
   }
   
-  func testDownloadFileAndPublishDownloadedURLs() {
-//    CZHttpFileManager.shared.cache.clearCache()
-//    Thread.sleep(forTimeInterval: 1)
-    
+  func testDownloadFileAndPublishDownloadedURLs() {    
     let (waitForExpectatation, expectation) = CZTestUtils.waitWithInterval(Constant.timeOut, testCase: self)
     
     // Create mockDataMap.

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerTests.swift
@@ -22,11 +22,9 @@ final class CZDownloadedObserverManagerTests: XCTestCase {
   
   func testAddObserver() {
     let testDownloadedObserver = TestDownloadedObserver()
-    
     downloadedObserverManager.addObserver(testDownloadedObserver)
     let isContained = downloadedObserverManager.observers.contains(testDownloadedObserver)
     XCTAssertTrue(isContained, "downloadedObserverManager should have added testDownloadedObserver.")
-    
   }
   
   func testPublishDownloadedURLs() {

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
@@ -24,7 +24,7 @@ final class CZDownloadingObserverManagerIntegrationTests: XCTestCase {
     let httpFileManager = CZHttpFileManager()
     httpFileManager.cache.clearCache()
     Thread.sleep(forTimeInterval: 0.1)
-  }
+  }  
   
   override func setUp() {
     httpFileManager = CZHttpFileManager()

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerTests.swift
@@ -22,11 +22,9 @@ final class CZDownloadingObserverManagerTests: XCTestCase {
   
   func testAddObserver() {
     let testDownloadingObserver = TestDownloadingObserver()
-    
     downloadingObserverManager.addObserver(testDownloadingObserver)
     let isContained = downloadingObserverManager.observers.contains(testDownloadingObserver)
     XCTAssertTrue(isContained, "downloadingObserverManager should have added testDownloadingObserver.")
-    
   }
   
   func testPublishDownloadingURLs() {


### PR DESCRIPTION
[Major][BugFix][TestFix] Should only update visitedDate if itemKey already exists, otherwise it won't download as URL itemKey already exists in cachedItemDict.

- Fix Bug: Should only update visitedDate if itemKey already exists, otherwise it won't download as URL itemKey already exists in cachedItemDict.
- FixTest: Should call clearCache() to clear cached files, otherwise it returns the cached file directly without checking cachedItemDict.