### PR TITLE
[MileStone][FixCrash][Performance] Disable cache / replace downloading from HTTPRequestWorker directly to private CZHTTPManager.

### DIFF
--- a/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
@@ -69,15 +69,11 @@ open class CZBaseHttpFileCache<DataType: NSObjectProtocol>: NSObject {
   public let maxCacheSize: Int
 
   internal let memCache: NSCache<NSString, DataType>
-  private let operationQueue: OperationQueue
   private(set) var diskCacheManager: CZDiskCacheManager<DataType>!
   
   public init(maxCacheAge: TimeInterval = CacheConstant.kMaxFileAge,
               maxCacheSize: Int = CacheConstant.kMaxCacheSize,
               downloadedObserverManager: CZDownloadedObserverManager? = nil) {
-    operationQueue = OperationQueue()
-    operationQueue.maxConcurrentOperationCount = 60
-    
     // Memory cache
     memCache = NSCache()
     memCache.countLimit = 1000

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -117,7 +117,7 @@ extension CZDiskCacheManager {
       do {
         self.setCachedItemsDictForNewURL(url, fileSize: data.count)
         completeSetCachedItemsDict?()
-        try data.write(to: fileURL)
+        // try data.write(to: fileURL)
         completeSaveCachedFile?()
       } catch {
         assertionFailure("Failed to write file. Error - \(error.localizedDescription)")

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -60,7 +60,7 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
       qos: .default,
       attributes: .concurrent)
     
-    super.init()
+    super.init()    
   }
   
   /**

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -22,9 +22,9 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
     return URL(fileURLWithPath: cacheFolderHelper.cacheFolder + CacheConstant.kCachedItemsDictFile)
   }()
   
-  lazy var cachedItemsDictLock: CZMutexLock<CachedItemsDict> = {
+  lazy var cachedItemsDictLock: CZMutexLockWithNSLock<CachedItemsDict> = {
     let cachedItemsDict: CachedItemsDict = loadCachedItemsDict() ?? [:]
-    return CZMutexLock(cachedItemsDict)
+    return CZMutexLockWithNSLock(cachedItemsDict)
   }()
   
   var currentCacheSize: Int {

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -110,7 +110,9 @@ extension CZDiskCacheManager {
     let (fileURL, cacheKey) = getCacheFileInfo(forURL: url)
     
     // Disk cache
-    ioQueue.async(flags: .barrier) { [weak self] in
+    // ioQueue.async(flags: .barrier)
+    ioQueue.async
+    { [weak self] in
       guard let `self` = self else { return }
       do {
         self.setCachedItemsDictForNewURL(url, fileSize: data.count)
@@ -385,6 +387,10 @@ internal extension CZDiskCacheManager {
       return removeFileURLs
     }
     
+    guard !(removeFileURLs?.isEmpty ?? true) else {
+      return
+    }
+      
     // 2. Remove corresponding files from disk.
     self.ioQueue.async(flags: .barrier) {
       removeFileURLs?.forEach {

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -45,11 +45,11 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
     httpFileDownloadQueue.name = httpFileDownloadQueueName
     // .default QoS: between .userInteractive and .utility.
     httpFileDownloadQueue.qualityOfService = .default
-    httpFileDownloadQueue.maxConcurrentOperationCount = downloadQueueMaxConcurrent
+    // httpFileDownloadQueue.maxConcurrentOperationCount = downloadQueueMaxConcurrent
     
     httpFileDecodeQueue = OperationQueue()
     httpFileDownloadQueue.name = httpFileDecodeQueueName
-    httpFileDecodeQueue.maxConcurrentOperationCount = decodeQueueMaxConcurrent
+    // httpFileDecodeQueue.maxConcurrentOperationCount = decodeQueueMaxConcurrent
     super.init()
     
     // if shouldObserveOperations {
@@ -141,6 +141,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
 //            })
         }
       }, failure: { (task, error) in
+        CZSystemInfo.getURLSessionInfo()
         assertionFailure("Failed to download file. url = \(url), Error - \(error)")
         completion(nil, error, false)
       })
@@ -181,6 +182,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       
       if shouldObserveOperations {
         //dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), currentThread = \(Thread.current), downloadingURLs = \(downloadingURLs)")
+        CZSystemInfo.getURLSessionInfo()
         dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), Executing tasks: \(object.operations.count), currentThread = \(Thread.current)")
       }
     }

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -76,7 +76,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
                                progress: HTTPRequestWorker.Progress? = nil,
                                completion: @escaping Completion) {
     guard let url = url else { return }
-    
+        
     /*
     SimpleImageDownloader.shared.download(url) { (data: Data?) in
       guard let data = data.assertIfNil else { return }
@@ -94,12 +94,15 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       }
       
       MainQueueScheduler.async {
-         completion(outputHttpFile, nil, false)
+        dbgPrintWithFunc(self, "Downloaded - url = \(url)")
+        CZSystemInfo.getURLSessionInfo()
+        completion(outputHttpFile, nil, false)
       }
     }
     */
     
     // cancelDownload(with: url)
+    
     let operation = HttpFileDownloadOperation(
       url: url,
       progress: progress,
@@ -146,7 +149,9 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
         completion(nil, error, false)
       })
     operation.queuePriority = priority
+    
     httpFileDownloadQueue.addOperation(operation)
+    
  
   }
   

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -141,6 +141,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
 //            })
         }
       }, failure: { (task, error) in
+        assertionFailure("Failedd to download file. url = \(url), Error - \(error)")
         completion(nil, error, false)
       })
     operation.queuePriority = priority

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -45,11 +45,11 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
     httpFileDownloadQueue.name = httpFileDownloadQueueName
     // .default QoS: between .userInteractive and .utility.
     httpFileDownloadQueue.qualityOfService = .default
-    // httpFileDownloadQueue.maxConcurrentOperationCount = downloadQueueMaxConcurrent
+    httpFileDownloadQueue.maxConcurrentOperationCount = downloadQueueMaxConcurrent
     
     httpFileDecodeQueue = OperationQueue()
     httpFileDownloadQueue.name = httpFileDecodeQueueName
-    // httpFileDecodeQueue.maxConcurrentOperationCount = decodeQueueMaxConcurrent
+    httpFileDecodeQueue.maxConcurrentOperationCount = decodeQueueMaxConcurrent
     super.init()
     
     // if shouldObserveOperations {
@@ -187,7 +187,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       
       if shouldObserveOperations {
         //dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), currentThread = \(Thread.current), downloadingURLs = \(downloadingURLs)")
-        CZSystemInfo.getURLSessionInfo()
+        // CZSystemInfo.getURLSessionInfo()
         dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), Executing tasks: \(object.operations.count), currentThread = \(Thread.current)")
       }
     }

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -87,10 +87,10 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       shouldSerializeJson: false,
       queuePriority: priority,
       success: { [weak self] (task, data) in
-      guard let `self` = self, let data = data else {
-        completion(nil, WebHttpFileError.invalidData, false)
-        return
-      }
+        guard let `self` = self, let data = data.assertIfNil else {
+          completion(nil, WebHttpFileError.invalidData, false)
+          return
+        }
       
       // Decode Data to httpFile in OperationQueue.
       // If `decodeData` closure is nil, returns `data` directly without decoding.

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -93,7 +93,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       }
       
       MainQueueScheduler.async {
-        completion(outputHttpFile, nil, false)
+         completion(outputHttpFile, nil, false)
       }
     }
     

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -76,6 +76,28 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
                                progress: HTTPRequestWorker.Progress? = nil,
                                completion: @escaping Completion) {
     guard let url = url else { return }
+    
+    SimpleImageDownloader.shared.download(url) { (data: Data?) in
+      guard let data = data.assertIfNil else { return }
+      
+      var outputHttpFile: DataType? = data as? DataType
+      var ouputData: Data? = data
+      
+      // Decode from `data` to `(outputHttpFile, ouputData)` if applicable.
+      if let decodeData = decodeData {
+        guard let (decodedHttpFile, decodedData) = decodeData(data).assertIfNil else {
+          completion(nil, WebHttpFileError.invalidData, false)
+          return
+        }
+        (outputHttpFile, ouputData) = (decodedHttpFile, decodedData)
+      }
+      
+      MainQueueScheduler.async {
+        completion(outputHttpFile, nil, false)
+      }
+    }
+    
+    /*
     cancelDownload(with: url)
     
     let operation = HttpFileDownloadOperation(
@@ -123,6 +145,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       })
     operation.queuePriority = priority
     httpFileDownloadQueue.addOperation(operation)
+ */
   }
   
   @objc(cancelDownloadWithURL:)

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -141,7 +141,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
 //            })
         }
       }, failure: { (task, error) in
-        assertionFailure("Failedd to download file. url = \(url), Error - \(error)")
+        assertionFailure("Failed to download file. url = \(url), Error - \(error)")
         completion(nil, error, false)
       })
     operation.queuePriority = priority

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -179,7 +179,8 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       }
       
       if shouldObserveOperations {
-        dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), currentThread = \(Thread.current), downloadingURLs = \(downloadingURLs)")
+        //dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), currentThread = \(Thread.current), downloadingURLs = \(downloadingURLs)")
+        dbgPrint("[CZHttpFileDownloader] Queued tasks: \(object.operationCount), Executing tasks: \(object.operations.count), currentThread = \(Thread.current)")
       }
     }
   }

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -150,9 +150,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       })
     operation.queuePriority = priority
     
-    httpFileDownloadQueue.addOperation(operation)
-    
- 
+    httpFileDownloadQueue.addOperation(operation)     
   }
   
   @objc(cancelDownloadWithURL:)

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -82,37 +82,37 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
     
     // cancelDownload(with: url)
     
-    httpManager.GET(
-      url.absoluteString,
-      shouldSerializeJson: false,
-      queuePriority: priority,
+    let operation = HttpFileDownloadOperation(
+      url: url,
+      httpManager: httpManager,
+      progress: progress,
       success: { [weak self] (task, data) in
-        guard let `self` = self, let data = data.assertIfNil else {
+        guard let `self` = self, let data = data else {
           completion(nil, WebHttpFileError.invalidData, false)
           return
         }
-      
-      // Decode Data to httpFile in OperationQueue.
-      // If `decodeData` closure is nil, returns `data` directly without decoding.
-      // - Note: you may customize decoding with additional work. e.g. Decode to UIImage and then crop.
-      self.httpFileDecodeQueue.addOperation {
-        var outputHttpFile: DataType? = data as? DataType
-        var ouputData: Data? = data
         
-        // Decode from `data` to `(outputHttpFile, ouputData)` if applicable.
-        if let decodeData = decodeData {
-          guard let (decodedHttpFile, decodedData) = decodeData(data).assertIfNil else {
-            completion(nil, WebHttpFileError.invalidData, false)
-            return
+        // Decode Data to httpFile in OperationQueue.
+        // If `decodeData` closure is nil, returns `data` directly without decoding.
+        // - Note: you may customize decoding with additional work. e.g. Decode to UIImage and then crop.
+        self.httpFileDecodeQueue.addOperation {
+          var outputHttpFile: DataType? = data as? DataType
+          var ouputData: Data? = data
+          
+          // Decode from `data` to `(outputHttpFile, ouputData)` if applicable.
+          if let decodeData = decodeData {
+            guard let (decodedHttpFile, decodedData) = decodeData(data).assertIfNil else {
+              completion(nil, WebHttpFileError.invalidData, false)
+              return
+            }
+            (outputHttpFile, ouputData) = (decodedHttpFile, decodedData)
           }
-          (outputHttpFile, ouputData) = (decodedHttpFile, decodedData)
-        }
-        
-        MainQueueScheduler.async {
-          completion(outputHttpFile, nil, false)
-        }
-        
-        // Save downloaded file to cache.
+          
+          MainQueueScheduler.async {
+            completion(outputHttpFile, nil, false)
+          }
+          
+          // Save downloaded file to cache.
 //          self.cache.setCacheFile(
 //            withUrl: url,
 //            data: ouputData,
@@ -122,13 +122,15 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
 //                completion(outputHttpFile, nil, false)
 //              }
 //            })
-      }
-    }, failure: { (task, error) in
-      CZSystemInfo.getURLSessionInfo()
-      assertionFailure("Failed to download file. url = \(url), Error - \(error)")
-      completion(nil, error, false)
-    }, progress: progress)
+        }
+      }, failure: { (task, error) in
+        CZSystemInfo.getURLSessionInfo()
+        assertionFailure("Failed to download file. url = \(url), Error - \(error)")
+        completion(nil, error, false)
+      })
+    operation.queuePriority = priority
     
+    httpFileDownloadQueue.addOperation(operation)    
   }
   
   @objc(cancelDownloadWithURL:)

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -77,6 +77,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
                                completion: @escaping Completion) {
     guard let url = url else { return }
     
+    /*
     SimpleImageDownloader.shared.download(url) { (data: Data?) in
       guard let data = data.assertIfNil else { return }
       
@@ -96,10 +97,9 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
          completion(outputHttpFile, nil, false)
       }
     }
+    */
     
-    /*
-    cancelDownload(with: url)
-    
+    // cancelDownload(with: url)
     let operation = HttpFileDownloadOperation(
       url: url,
       progress: progress,
@@ -145,7 +145,7 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
       })
     operation.queuePriority = priority
     httpFileDownloadQueue.addOperation(operation)
- */
+ 
   }
   
   @objc(cancelDownloadWithURL:)

--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -103,16 +103,20 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
             (outputHttpFile, ouputData) = (decodedHttpFile, decodedData)
           }
           
+          MainQueueScheduler.async {
+            completion(outputHttpFile, nil, false)
+          }
+          
           // Save downloaded file to cache.
-          self.cache.setCacheFile(
-            withUrl: url,
-            data: ouputData,
-            completeSetCachedItemsDict: {
-              // Call completion on mainQueue - after setting CachedItems info to ensure downloaded state.
-              MainQueueScheduler.async {
-                completion(outputHttpFile, nil, false)
-              }
-            })
+//          self.cache.setCacheFile(
+//            withUrl: url,
+//            data: ouputData,
+//            completeSetCachedItemsDict: {
+//              // Call completion on mainQueue - after setting CachedItems info to ensure downloaded state.
+//              MainQueueScheduler.async {
+//                completion(outputHttpFile, nil, false)
+//              }
+//            })
         }
       }, failure: { (task, error) in
         completion(nil, error, false)

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -40,6 +40,14 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
                            priority: Operation.QueuePriority = .normal,
                            progress: HTTPRequestWorker.Progress? = nil,
                            completion: @escaping CZHttpFileDownloderCompletion) {
+    
+    SimpleImageDownloader.shared.download(url) { (data: Data?) in
+      MainQueueScheduler.sync {
+        completion(data as Data?, nil, false)
+      }
+    }
+    
+    /*
     cache.getCachedFile(withUrl: url) { [weak self] (data: NSData?) in
       guard let `self` = self else { return }
       if CZHttpFileDownloaderConfig.enableLocalCache,
@@ -63,6 +71,7 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
           completion(data as Data?, error, fromCache)
         })
     }
+ */
   }
   
   @objc(cancelDownloadWithURL:)

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -40,14 +40,7 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
                            priority: Operation.QueuePriority = .normal,
                            progress: HTTPRequestWorker.Progress? = nil,
                            completion: @escaping CZHttpFileDownloderCompletion) {
-    
-    SimpleImageDownloader.shared.download(url) { (data: Data?) in
-      MainQueueScheduler.sync {
-        completion(data as Data?, nil, false)
-      }
-    }
-    
-    /*
+        
     cache.getCachedFile(withUrl: url) { [weak self] (data: NSData?) in
       guard let `self` = self else { return }
       if CZHttpFileDownloaderConfig.enableLocalCache,
@@ -71,7 +64,7 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
           completion(data as Data?, error, fromCache)
         })
     }
- */
+ 
   }
   
   @objc(cancelDownloadWithURL:)

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -19,16 +19,16 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
   public let downloader: CZHttpFileDownloader<NSData>
   public let cache: CZHttpFileCache
   
-  public let downloadingObserverManager: CZDownloadingObserverManager
-  public let downloadedObserverManager: CZDownloadedObserverManager
+  public var downloadingObserverManager: CZDownloadingObserverManager?
+  public var downloadedObserverManager: CZDownloadedObserverManager?
   
   public enum Config {
     public static var maxConcurrencies = 5
   }
   
   public override init() {
-    downloadingObserverManager = CZDownloadingObserverManager()
-    downloadedObserverManager = CZDownloadedObserverManager()
+//    downloadingObserverManager = CZDownloadingObserverManager()
+//    downloadedObserverManager = CZDownloadedObserverManager()
     cache = CZHttpFileCache(downloadedObserverManager: downloadedObserverManager)
     downloader = CZHttpFileDownloader(cache: cache, downloadingObserverManager: downloadingObserverManager)
     super.init()    
@@ -106,6 +106,6 @@ private extension CZHttpFileManager {
       return
     }
     let progress = Double(currSize) / Double(totalSize)
-    downloadingObserverManager.publishDownloadingProgress(url: downloadURL, progress: progress)
+    downloadingObserverManager?.publishDownloadingProgress(url: downloadURL, progress: progress)
   }
 }

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -33,11 +33,7 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
       self?.finish()
       failure?(task, error)
     }
-  }
-  
-  deinit {
-    
-  }
+  }  
   
   override func _execute() {
     downloadHttpFile(url: url)

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -51,7 +51,6 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
 
 private extension HttpFileDownloadOperation {
   func downloadHttpFile(url: URL) {
-      // CZHTTPManager.shared.GET(
       httpManager?.GET(
       url.absoluteString,
         shouldSerializeJson: false,

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -75,22 +75,23 @@ private extension HttpFileDownloadOperation {
     } else {
       
       // * Crash.
-//      CZHTTPManager.shared.GET(
-//        url.absoluteString,
-//        shouldSerializeJson: false,
-//        success: success,
-//        failure: failure,
-//        progress: progress)
-      
-      requester = HTTPRequestWorker(
-        .GET,
-        url: url,
-        params: nil,
+      CZHTTPManager.shared.GET(
+        url.absoluteString,
         shouldSerializeJson: false,
         success: success,
         failure: failure,
         progress: progress)
-      requester?.start()
+      
+//      requester = HTTPRequestWorker(
+//        .GET,
+//        url: url,
+//        params: nil,
+//        shouldSerializeJson: false,
+//        success: success,
+//        failure: failure,
+//        progress: progress)
+//      requester?.start()
+      
       // requester?.testStartFetch()
     }
   }

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -22,16 +22,16 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
     super.init()
     
     self.props["url"] = url
-    self.success = { [weak self] (data, reponse) in
+    self.success = { [weak self] (task, data) in
       // Update Operation's `isFinished` prop
       self?.finish()
-      success?(data, reponse)
+      success?(task, data)
     }
     
-    self.failure = { [weak self] (reponse, error) in
+    self.failure = { [weak self] (task, error) in
       // Update Operation's `isFinished` prop
       self?.finish()
-      failure?(reponse, error)
+      failure?(task, error)
     }
   }
   
@@ -48,15 +48,25 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
 
 private extension HttpFileDownloadOperation {
   func downloadHttpFile(url: URL) {
-    requester = HTTPRequestWorker(
-      .GET,
-      url: url,
-      params: nil,
-      shouldSerializeJson: false,
-      success: success,
-      failure: failure,
-      progress: progress)
-    requester?.start()
+    URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+      guard let `self` = self else { return }
+      if let error = error {
+        self.failure?(nil, error)
+        return
+      }
+       self.success?(nil, data)
+    }.resume()
+
+    
+//    requester = HTTPRequestWorker(
+//      .GET,
+//      url: url,
+//      params: nil,
+//      shouldSerializeJson: false,
+//      success: success,
+//      failure: failure,
+//      progress: progress)
+//    requester?.start()
   }
 }
 

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -35,6 +35,10 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
     }
   }
   
+  deinit {
+    
+  }
+  
   override func _execute() {
     downloadHttpFile(url: url)
   }
@@ -48,25 +52,53 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
 
 private extension HttpFileDownloadOperation {
   func downloadHttpFile(url: URL) {
-    URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
-      guard let `self` = self else { return }
-      if let error = error {
-        self.failure?(nil, error)
-        return
-      }
-       self.success?(nil, data)
-    }.resume()
+    if (true) {
+      
+      // * TEST - Fixed crash!
+      URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+        guard let `self` = self else { return }
+        if let error = error {
+          self.failure?(nil, error)
+          return
+        }
+         self.success?(nil, data)
+      }.resume()
 
+      
+//      URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+//        guard let `self` = self else { return }
+//        // * Add MainQueueScheduler.
+//        MainQueueScheduler.async {
+//          if let error = error {
+//            self.failure?(nil, error)
+//            return
+//          }
+//          self.success?(nil, data)
+//        }
+//      }.resume()
     
-//    requester = HTTPRequestWorker(
-//      .GET,
-//      url: url,
-//      params: nil,
-//      shouldSerializeJson: false,
-//      success: success,
-//      failure: failure,
-//      progress: progress)
-//    requester?.start()
+    } else {
+      
+      // * Crash.
+//      CZHTTPManager.shared.GET(
+//        url.absoluteString,
+//        shouldSerializeJson: false,
+//        success: success,
+//        failure: failure,
+//        progress: progress)
+      
+      requester = HTTPRequestWorker(
+        .GET,
+        url: url,
+        params: nil,
+        shouldSerializeJson: false,
+        success: success,
+        failure: failure,
+        progress: progress)
+      //requester?.start()
+      
+      requester?.testStartFetch()
+    }
   }
 }
 

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -48,7 +48,7 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
 
 private extension HttpFileDownloadOperation {
   func downloadHttpFile(url: URL) {
-    if (true) {
+    if (false) {
       
       // * TEST - Fixed crash!
       URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
@@ -59,7 +59,6 @@ private extension HttpFileDownloadOperation {
         }
          self.success?(nil, data)
       }.resume()
-
       
 //      URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
 //        guard let `self` = self else { return }
@@ -91,9 +90,8 @@ private extension HttpFileDownloadOperation {
         success: success,
         failure: failure,
         progress: progress)
-      //requester?.start()
-      
-      requester?.testStartFetch()
+      requester?.start()
+      // requester?.testStartFetch()
     }
   }
 }

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -12,12 +12,15 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
   private var success: HTTPRequestWorker.Success?
   private var failure: HTTPRequestWorker.Failure?
   let url: URL
-  
+  private weak var httpManager: CZHTTPManager?
+    
   required init(url: URL,
+                httpManager: CZHTTPManager,
                 progress: HTTPRequestWorker.Progress? = nil,
                 success: HTTPRequestWorker.Success?,
                 failure: HTTPRequestWorker.Failure?) {
     self.url = url
+    self.httpManager = httpManager
     self.progress = progress
     super.init()
     
@@ -48,35 +51,9 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
 
 private extension HttpFileDownloadOperation {
   func downloadHttpFile(url: URL) {
-    if (false) {
-      
-      // * TEST - Fixed crash!
-      URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
-        guard let `self` = self else { return }
-        if let error = error {
-          self.failure?(nil, error)
-          return
-        }
-         self.success?(nil, data)
-      }.resume()
-      
-//      URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
-//        guard let `self` = self else { return }
-//        // * Add MainQueueScheduler.
-//        MainQueueScheduler.async {
-//          if let error = error {
-//            self.failure?(nil, error)
-//            return
-//          }
-//          self.success?(nil, data)
-//        }
-//      }.resume()
-    
-    } else {
-      
-      // * Crash.
-      CZHTTPManager.shared.GET(
-        url.absoluteString,
+      // CZHTTPManager.shared.GET(
+      httpManager?.GET(
+      url.absoluteString,
         shouldSerializeJson: false,
         success: success,
         failure: failure,
@@ -91,9 +68,7 @@ private extension HttpFileDownloadOperation {
 //        failure: failure,
 //        progress: progress)
 //      requester?.start()
-      
-      // requester?.testStartFetch()
-    }
+
   }
 }
 

--- a/Sources/CZHttpFile/SimpleImageDownloader.swift
+++ b/Sources/CZHttpFile/SimpleImageDownloader.swift
@@ -1,0 +1,50 @@
+import UIKit
+
+class SimpleImageDownloader {
+    typealias Completion = (Data?) -> Void
+    static let shared = SimpleImageDownloader()
+    // private let imageCache = HTTPCache()
+    
+    func download(_ url: URL, completion: @escaping Completion) {
+//        // Fetch from cache
+//        if let data = imageCache.object(for: url) {
+//            completion(data)
+//            return
+//        }
+        
+        // Fetch from network
+        URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+            guard let `self` = self,
+                let data = data else {
+                    return
+            }
+            // Save to cache
+            // self.imageCache.save(data, for: url)
+          
+            // completion
+            completion(data)
+        }.resume()
+    }
+}
+
+private var imageKey: UInt8 = 0
+extension UIImageView {
+    var imageUrl: URL? {
+        get { return objc_getAssociatedObject(self, &imageKey) as? URL }
+        set { objc_setAssociatedObject(self, &imageKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+    
+    func download(_ url: URL) {
+        imageUrl = url
+        SimpleImageDownloader.shared.download(url) { [weak self] (data) in
+            guard let `self` = self else { return }
+            guard let data = data,
+                url == self.imageUrl else {
+                    return
+            }
+            DispatchQueue.main.async {
+                self.image = UIImage(data: data)
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Updates

- Disable cache 
  - Remove .barrier: ioQueue.async(flags: .barrier) => ioQueue.async
  - self.ioQueue.sync => self.ioQueue.async 
  - cachedItemsDictLockWrite(isAsync: false) => cachedItemsDictLockWrite(isAsync: true)

- Replace downloading from HTTPRequestWorker directly to private CZHTTPManager