### PR TITLE
[MileStone][Performance] Add back flushCachedItemsDictToDisk().

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/geekaurora/CZNetworking.git",
         "state": {
           "branch": null,
-          "revision": "e54a91f66ec8c4c9eec295557a8411e37acac775",
-          "version": "3.3.6"
+          "revision": "c867e0ec09afde22c0f62c04e3794e4a044ab42d",
+          "version": "3.4.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/geekaurora/CZUtils.git",
         "state": {
           "branch": null,
-          "revision": "f85bb39555a71578d534f6b84952f02c8730e0f2",
-          "version": "3.8.1"
+          "revision": "f7b031ab66cfc3a60dad74cdbd2ca3682a31c283",
+          "version": "4.1.2"
         }
       }
     ]

--- a/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
@@ -45,7 +45,7 @@ public enum CacheConstant {
   public static let kMaxCacheSize: Int = 500 * 1024 * 1024
   public static let kCachedItemsDictFile = "cachedItemsDict.plist"
   public static let kFileModifiedDate = "modifiedDate"
-  // public static let kFileVisitedDate = "visitedDate"
+  public static let kFileVisitedDate = "visitedDate"
   public static let kHttpUrlString = "url"
   public static let kFileSize = "size"
   public static let ioQueueLabel = "com.tony.cache.ioQueue"

--- a/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
@@ -45,7 +45,7 @@ public enum CacheConstant {
   public static let kMaxCacheSize: Int = 500 * 1024 * 1024
   public static let kCachedItemsDictFile = "cachedItemsDict.plist"
   public static let kFileModifiedDate = "modifiedDate"
-  public static let kFileVisitedDate = "visitedDate"
+  // public static let kFileVisitedDate = "visitedDate"
   public static let kHttpUrlString = "url"
   public static let kFileSize = "size"
   public static let ioQueueLabel = "com.tony.cache.ioQueue"

--- a/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
@@ -73,6 +73,7 @@ open class CZBaseHttpFileCache<DataType: NSObjectProtocol>: NSObject {
   
   public init(maxCacheAge: TimeInterval = CacheConstant.kMaxFileAge,
               maxCacheSize: Int = CacheConstant.kMaxCacheSize,
+              shouldEnableCachedItemsDict: Bool = false,
               downloadedObserverManager: CZDownloadedObserverManager? = nil) {
     // Memory cache
     memCache = NSCache()
@@ -87,6 +88,7 @@ open class CZBaseHttpFileCache<DataType: NSObjectProtocol>: NSObject {
       maxCacheAge: maxCacheAge,
       maxCacheSize: maxCacheSize,
       cacheFolderName: cacheFolderName,
+      shouldEnableCachedItemsDict: shouldEnableCachedItemsDict,
       transformMetadataToCachedData: transformMetadataToCachedData,
       downloadedObserverManager: downloadedObserverManager)
     

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -60,7 +60,7 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
   public init(maxCacheAge: TimeInterval,
               maxCacheSize: Int,
               cacheFolderName: String,
-              shouldEnableCachedItemsDict: Bool = true,
+              shouldEnableCachedItemsDict: Bool = false,
               transformMetadataToCachedData: @escaping TransformMetadataToCachedData,
               downloadedObserverManager: CZDownloadedObserverManager? = nil) {
     self.maxCacheAge = maxCacheAge

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -195,7 +195,7 @@ extension CZDiskCacheManager {
         cachedItemsDict[key] = [:]
       }
       cachedItemsDict[key]?[subkey] = value
-      // self.flushCachedItemsDictToDisk(cachedItemsDict)
+      self.flushCachedItemsDictToDisk(cachedItemsDict)
   }
   
   /**
@@ -223,7 +223,7 @@ extension CZDiskCacheManager {
 //  }
   
   func flushCachedItemsDictToDisk(_ cachedItemsDict: CachedItemsDict) {
-    // (cachedItemsDict as NSDictionary).write(to: cachedItemsDictFileURL, atomically: true)
+    (cachedItemsDict as NSDictionary).write(to: cachedItemsDictFileURL, atomically: true)
   }
   
   func cachedItemsDictLockWrite<Result>(isAsync: Bool = false,

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -57,6 +57,7 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
   ///
   /// - Parameters:
   ///   - shouldEnableCachedItemsDict: Indicates whether to save cached file information. e.g. url, size. Defaults to false.
+  ///     false for CZWebImage. true for CZHttpFile - large files.
   public init(maxCacheAge: TimeInterval,
               maxCacheSize: Int,
               cacheFolderName: String,

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -6,8 +6,8 @@ public typealias CleanDiskCacheCompletion = () -> Void
 public typealias SetCacheFileCompletion = () -> Void
 internal typealias CachedItemsDict = [String: [String: Any]]
 
-private enum CZDiskCacheManagerConstant {
-  static let debounceTaskSchedulerGap: TimeInterval = 1
+internal enum CZDiskCacheManagerConstant {
+  static var debounceTaskSchedulerGap: TimeInterval = 5
 }
 
 /**

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -156,7 +156,7 @@ extension CZDiskCacheManager {
       if let data = try? Data(contentsOf: fileURL),
          let image = self.transformMetadataToCachedData(data).assertIfNil {
         // Update last visited date
-        self.setCachedItemsDict(key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate(), skipIfKeyNotExists: true)
+        // self.setCachedItemsDict(key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate(), skipIfKeyNotExists: true)
         completion(image)
       } else {
         completion(nil)

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -137,7 +137,7 @@ extension CZDiskCacheManager {
       if let data = try? Data(contentsOf: fileURL),
          let image = self.transformMetadataToCachedData(data).assertIfNil {
         // Update last visited date
-        self.setCachedItemsDict(key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate(), skipIfKeyNotExists: true)
+        // self.setCachedItemsDict(key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate(), skipIfKeyNotExists: true)
         completion(image)
       } else {
         completion(nil)
@@ -161,7 +161,7 @@ extension CZDiskCacheManager {
       }
       self.setCachedItemsDictWithoutLock(cachedItemsDict: &cachedItemsDict, key: cacheKey, subkey: CacheConstant.kHttpUrlString, value: httpURL.absoluteString)
       self.setCachedItemsDictWithoutLock(cachedItemsDict: &cachedItemsDict, key: cacheKey, subkey: CacheConstant.kFileModifiedDate, value: NSDate())
-      self.setCachedItemsDictWithoutLock(cachedItemsDict: &cachedItemsDict, key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate())
+//      self.setCachedItemsDictWithoutLock(cachedItemsDict: &cachedItemsDict, key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate())
       self.setCachedItemsDictWithoutLock(cachedItemsDict: &cachedItemsDict, key: cacheKey, subkey: CacheConstant.kFileSize, value: fileSize)
       
     }
@@ -327,8 +327,8 @@ internal extension CZDiskCacheManager {
         sortCachedItemsDictClosure: { (keyValue1: (key: String, value: [String : Any]),
                                        keyValue2: (key: String, value: [String : Any])) -> Bool in
           // Sort files with last visted date
-          if let modifiedDate1 = keyValue1.value[CacheConstant.kFileVisitedDate] as? Date,
-             let modifiedDate2 = keyValue2.value[CacheConstant.kFileVisitedDate] as? Date {
+          if let modifiedDate1 = keyValue1.value[CacheConstant.kFileModifiedDate] as? Date,
+             let modifiedDate2 = keyValue2.value[CacheConstant.kFileModifiedDate] as? Date {
             return modifiedDate1.timeIntervalSince(modifiedDate2) < 0
           } else {
             fatalError()

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -55,7 +55,7 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
   public init(maxCacheAge: TimeInterval,
               maxCacheSize: Int,
               cacheFolderName: String,
-              shouldEnableCachedItemsDict: Bool = false,
+              shouldEnableCachedItemsDict: Bool = true,
               transformMetadataToCachedData: @escaping TransformMetadataToCachedData,
               downloadedObserverManager: CZDownloadedObserverManager? = nil) {
     self.maxCacheAge = maxCacheAge
@@ -148,7 +148,7 @@ extension CZDiskCacheManager {
       if let data = try? Data(contentsOf: fileURL),
          let image = self.transformMetadataToCachedData(data).assertIfNil {
         // Update last visited date
-        // self.setCachedItemsDict(key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate(), skipIfKeyNotExists: true)
+        self.setCachedItemsDict(key: cacheKey, subkey: CacheConstant.kFileVisitedDate, value: NSDate(), skipIfKeyNotExists: true)
         completion(image)
       } else {
         completion(nil)

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -22,13 +22,16 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
     return URL(fileURLWithPath: cacheFolderHelper.cacheFolder + CacheConstant.kCachedItemsDictFile)
   }()
   
-  lazy var cachedItemsDictLock: CZMutexLockWithNSLock<CachedItemsDict> = {
+  lazy var cachedItemsDictLock: CZMutexLockWithNSLock<CachedItemsDict>? = {
+    guard shouldEnableCachedItemsDict else {
+      return nil
+    }
     let cachedItemsDict: CachedItemsDict = loadCachedItemsDict() ?? [:]
     return CZMutexLockWithNSLock(cachedItemsDict)
   }()
   
   var currentCacheSize: Int {
-    return cachedItemsDictLock.readLock { [weak self] (cachedItemsDict: CachedItemsDict) -> Int in
+    return cachedItemsDictLock?.readLock { [weak self] (cachedItemsDict: CachedItemsDict) -> Int in
       guard let `self` = self else {return 0}
       return self.getSizeWithoutLock(cachedItemsDict: cachedItemsDict)
     } ?? 0
@@ -37,20 +40,28 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
   let maxCacheAge: TimeInterval
   let maxCacheSize: Int
   let ioQueue: DispatchQueue
+  let shouldEnableCachedItemsDict: Bool
   private(set) weak var downloadedObserverManager: CZDownloadedObserverManager?
 
   private let transformMetadataToCachedData: TransformMetadataToCachedData
   
   // MARK: - Initializer
   
+  
+  /// Initialization of CZDiskCacheManager.
+  ///
+  /// - Parameters:
+  ///   - shouldEnableCachedItemsDict: Indicates whether to save cached file information. e.g. url, size. Defaults to false.
   public init(maxCacheAge: TimeInterval,
               maxCacheSize: Int,
               cacheFolderName: String,
+              shouldEnableCachedItemsDict: Bool = false,
               transformMetadataToCachedData: @escaping TransformMetadataToCachedData,
               downloadedObserverManager: CZDownloadedObserverManager? = nil) {
     self.maxCacheAge = maxCacheAge
     self.maxCacheSize = maxCacheSize
     self.cacheFolderName = cacheFolderName
+    self.shouldEnableCachedItemsDict = shouldEnableCachedItemsDict
     self.downloadedObserverManager = downloadedObserverManager
     self.transformMetadataToCachedData = transformMetadataToCachedData
 
@@ -79,7 +90,7 @@ internal class CZDiskCacheManager<DataType: NSObjectProtocol>: NSObject {
    Returns whether `httpURL` file has been downloaded  and exists in the cache.
    */
   func urlExistsInCache(_ httpURL: URL) -> Bool {
-    return cachedItemsDictLock.readLock { [weak self] (cachedItemsDict) -> Bool? in
+    return cachedItemsDictLock?.readLock { [weak self] (cachedItemsDict) -> Bool? in
       guard let `self` = self else { return false}
       
       let (_, cacheKey) = self.getCacheFileInfo(forURL: httpURL)
@@ -204,7 +215,7 @@ extension CZDiskCacheManager {
    Should call `cachedItemsDictLock.readLock` to read cachedItemsDict for data consistency.
    */
   func getCachedItemsDict() -> CachedItemsDict {
-    return cachedItemsDictLock.readLock { (cachedItemsDict) -> CachedItemsDict? in
+    return cachedItemsDictLock?.readLock { (cachedItemsDict) -> CachedItemsDict? in
       cachedItemsDict
     } ?? [:]
   }
@@ -223,13 +234,19 @@ extension CZDiskCacheManager {
 //  }
   
   func flushCachedItemsDictToDisk(_ cachedItemsDict: CachedItemsDict) {
+    guard shouldEnableCachedItemsDict else {
+      return
+    }
     (cachedItemsDict as NSDictionary).write(to: cachedItemsDictFileURL, atomically: true)
   }
   
   func cachedItemsDictLockWrite<Result>(isAsync: Bool = false,
                                         closure: @escaping (inout CachedItemsDict) -> Result?) -> Result? {
-    // Get result throught write lock.
-    let result = cachedItemsDictLock.writeLock(isAsync: isAsync, closure)
+    guard shouldEnableCachedItemsDict else {
+      return nil
+    }
+    // Get result through write lock.
+    let result = cachedItemsDictLock?.writeLock(isAsync: isAsync, closure)
     
     // Publish DownloadedURLs.
     publishDownloadedURLs()
@@ -263,7 +280,7 @@ extension CZDiskCacheManager {
    Returns HTTP URL strings of downloaded files.
    */
   func cachedFileHttpURLs() -> [String] {
-    return cachedItemsDictLock.readLock { (cachedItemsDict) -> [String] in
+    return cachedItemsDictLock?.readLock { (cachedItemsDict) -> [String] in
       cachedItemsDict
         .keys
         .sorted(by: { (key0, key1) -> Bool in
@@ -307,7 +324,7 @@ internal extension CZDiskCacheManager {
   }
   
   func cleanDiskCacheIfNeeded(completion: CleanDiskCacheCompletion? = nil) {
-    // 1. Clean disk by age
+    // 1. Clean disk by age.
     let currDate = Date()
     cleanDiskCache { (itemInfo: [String : Any]) -> Bool in
       guard let modifiedDate = itemInfo[CacheConstant.kFileModifiedDate] as? Date else {
@@ -316,7 +333,7 @@ internal extension CZDiskCacheManager {
       return currDate.timeIntervalSince(modifiedDate) > self.maxCacheAge
     }
     
-    // 2. Clean disk by maxSize setting: based on visited date - simple LRU
+    // 2. Clean disk by maxSize setting: based on visited date - simple LRU.
     if self.currentCacheSize > self.maxCacheSize {
       let expectedCacheSize = self.maxCacheSize / 2
       let expectedReduceSize = self.currentCacheSize - expectedCacheSize

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -27,8 +27,8 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
   }
   
   public override init() {
-//    downloadingObserverManager = CZDownloadingObserverManager()
-//    downloadedObserverManager = CZDownloadedObserverManager()
+    downloadingObserverManager = CZDownloadingObserverManager()
+    downloadedObserverManager = CZDownloadedObserverManager()
     cache = CZHttpFileCache(downloadedObserverManager: downloadedObserverManager)
     downloader = CZHttpFileDownloader(cache: cache, downloadingObserverManager: downloadingObserverManager)
     super.init()    

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -24,11 +24,14 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
   
   public enum Config {
     public static var maxConcurrencies = 5
+    public static var shouldEnableDownloadObservers = false
   }
   
   public override init() {
-    downloadingObserverManager = CZDownloadingObserverManager()
-    downloadedObserverManager = CZDownloadedObserverManager()
+    if Config.shouldEnableDownloadObservers {
+      downloadingObserverManager = CZDownloadingObserverManager()
+      downloadedObserverManager = CZDownloadedObserverManager()
+    }
     cache = CZHttpFileCache(downloadedObserverManager: downloadedObserverManager)
     downloader = CZHttpFileDownloader(cache: cache, downloadingObserverManager: downloadingObserverManager)
     super.init()    

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -25,6 +25,7 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
   public enum Config {
     public static var maxConcurrencies = 5
     public static var shouldEnableDownloadObservers = false
+    public static var shouldEnableCachedItemsDict = true
   }
   
   public override init() {
@@ -32,9 +33,12 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
       downloadingObserverManager = CZDownloadingObserverManager()
       downloadedObserverManager = CZDownloadedObserverManager()
     }
-    cache = CZHttpFileCache(downloadedObserverManager: downloadedObserverManager)
+    
+    cache = CZHttpFileCache(
+      shouldEnableCachedItemsDict: Config.shouldEnableCachedItemsDict,
+      downloadedObserverManager: downloadedObserverManager)
     downloader = CZHttpFileDownloader(cache: cache, downloadingObserverManager: downloadingObserverManager)
-    super.init()    
+    super.init()
   }
   
   // MARK: - Download

--- a/Sources/CZHttpFile/HttpFileDownloadOperation.swift
+++ b/Sources/CZHttpFile/HttpFileDownloadOperation.swift
@@ -51,23 +51,23 @@ class HttpFileDownloadOperation: ConcurrentBlockOperation {
 
 private extension HttpFileDownloadOperation {
   func downloadHttpFile(url: URL) {
-      httpManager?.GET(
+    httpManager?.GET(
       url.absoluteString,
-        shouldSerializeJson: false,
-        success: success,
-        failure: failure,
-        progress: progress)
-      
-//      requester = HTTPRequestWorker(
-//        .GET,
-//        url: url,
-//        params: nil,
-//        shouldSerializeJson: false,
-//        success: success,
-//        failure: failure,
-//        progress: progress)
-//      requester?.start()
-
+      shouldSerializeJson: false,
+      success: success,
+      failure: failure,
+      progress: progress)
+    
+    //      requester = HTTPRequestWorker(
+    //        .GET,
+    //        url: url,
+    //        params: nil,
+    //        shouldSerializeJson: false,
+    //        success: success,
+    //        failure: failure,
+    //        progress: progress)
+    //      requester?.start()
+    
   }
 }
 

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
@@ -40,8 +40,8 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
     CZHTTPManager.stubMockData(dict: mockDataDict)
     
     // 1. Add observer.
-    httpFileManager.downloadedObserverManager.addObserver(testDownloadedObserver)
-    let isContained = httpFileManager.downloadedObserverManager.observers.contains(testDownloadedObserver)
+    httpFileManager.downloadedObserverManager?.addObserver(testDownloadedObserver)
+    let isContained = httpFileManager.downloadedObserverManager?.observers.contains(testDownloadedObserver) ?? false
     XCTAssertTrue(isContained, "downloadedObserverManager should have added testDownloadedObserver.")
     
     // 2. Download file.

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
@@ -27,7 +27,7 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
   }
   
   override func setUp() {
-    CZHttpFileManager.Config.shouldEnableDownloadObservers = true      
+    CZHttpFileManager.Config.shouldEnableDownloadObservers = true
     httpFileManager = CZHttpFileManager()
     testDownloadedObserver = TestDownloadedObserver()
   }
@@ -41,7 +41,7 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
     CZHTTPManager.stubMockData(dict: mockDataDict)
     
     // 1. Add observer.
-    httpFileManager.downloadedObserverManager?.addObserver(testDownloadedObserver)
+    httpFileManager.downloadedObserverManager!.addObserver(testDownloadedObserver)
     let isContained = httpFileManager.downloadedObserverManager?.observers.contains(testDownloadedObserver) ?? false
     XCTAssertTrue(isContained, "downloadedObserverManager should have added testDownloadedObserver.")
     

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadedObserverManagerIntegrationTests.swift
@@ -27,6 +27,7 @@ final class CZDownloadedObserverManagerIntegrationTests: XCTestCase {
   }
   
   override func setUp() {
+    CZHttpFileManager.Config.shouldEnableDownloadObservers = true      
     httpFileManager = CZHttpFileManager()
     testDownloadedObserver = TestDownloadedObserver()
   }

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
@@ -41,7 +41,7 @@ final class CZDownloadingObserverManagerIntegrationTests: XCTestCase {
     CZHTTPManager.stubMockData(dict: mockDataDict)
     
     // 1. Add observer.
-    httpFileManager.downloadingObserverManager?.addObserver(testDownloadingObserver)
+    httpFileManager.downloadingObserverManager!.addObserver(testDownloadingObserver)
     let isContained = httpFileManager.downloadingObserverManager?.observers.contains(testDownloadingObserver) ?? false
     XCTAssertTrue(isContained, "downloadingObserverManager should have added testDownloadingObserver.")
     

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
@@ -27,6 +27,7 @@ final class CZDownloadingObserverManagerIntegrationTests: XCTestCase {
   }  
   
   override func setUp() {
+    CZHttpFileManager.Config.shouldEnableDownloadObservers = true
     httpFileManager = CZHttpFileManager()
     testDownloadingObserver = TestDownloadingObserver()
   }

--- a/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
+++ b/Tests/CZHttpFileTests/ObserverTests/CZDownloadingObserverManagerIntegrationTests.swift
@@ -40,8 +40,8 @@ final class CZDownloadingObserverManagerIntegrationTests: XCTestCase {
     CZHTTPManager.stubMockData(dict: mockDataDict)
     
     // 1. Add observer.
-    httpFileManager.downloadingObserverManager.addObserver(testDownloadingObserver)
-    let isContained = httpFileManager.downloadingObserverManager.observers.contains(testDownloadingObserver)
+    httpFileManager.downloadingObserverManager?.addObserver(testDownloadingObserver)
+    let isContained = httpFileManager.downloadingObserverManager?.observers.contains(testDownloadingObserver) ?? false
     XCTAssertTrue(isContained, "downloadingObserverManager should have added testDownloadingObserver.")
     
     // 2. Download file.


### PR DESCRIPTION
Ticket: https://github.com/geekaurora/CZHttpFile/issues/35

Solution details can be found in Ticket: https://github.com/geekaurora/CZHttpFile/issues/35

## Solutions

**Without flushCachedItemsDictToDisk(): 60 FPS**

- **Flag shouldEnableCachedItemsDict:** indicates whether to save cached file information. e.g. url, size. Defaults to false. 
  - CZWebImage = false, CZHttpFile = true - large files.
- **DebounceTaskScheduler:** merges the same tasks with `gap` and only executes the last task.