### PR TITLE
[FixCrash] CZWebImage Crash - caused by WriteFile threadsafety.

### DIFF
--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -342,6 +342,10 @@ internal extension CZDiskCacheManager {
   }
   
   func cleanDiskCacheIfNeeded(completion: CleanDiskCacheCompletion? = nil) {
+    guard shouldEnableCachedItemsDict else {
+      return
+    }
+    
     // 1. Clean disk by age.
     let currDate = Date()
     cleanDiskCache { (itemInfo: [String : Any]) -> Bool in

--- a/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Utils/CZDiskCacheManager.swift
@@ -137,7 +137,7 @@ extension CZDiskCacheManager {
         self.setCachedItemsDictForNewURL(url, fileSize: data.count)
         completeSetCachedItemsDict?()
         // * Write file to disk.
-        // `.atomic`: if this write succeeds, moves the temporary file to its final location.
+        // `.atomic`: If write succeeds, moves the temporary file to its final location.
         try data.write(to: fileURL, options: [.atomic])
         completeSaveCachedFile?()
       } catch {


### PR DESCRIPTION
Details can be found in:
Ticket - https://github.com/geekaurora/CZHttpFile/issues/37

