### PR TITLE
[BugFix] CZHttpFileDownloader.downloadHttpFile() - completion closure is called twice.

### DIFF
--- a/Sources/CZHttpFile/CZHttpFileDownloader.swift
+++ b/Sources/CZHttpFile/CZHttpFileDownloader.swift
@@ -108,9 +108,9 @@ public class CZHttpFileDownloader<DataType: NSObjectProtocol>: NSObject {
             (outputHttpFile, ouputData) = (decodedHttpFile, decodedData)
           }
           
-          MainQueueScheduler.async {
-            completion(outputHttpFile, nil, false)
-          }
+//          MainQueueScheduler.async {
+//            completion(outputHttpFile, nil, false)
+//          }
           
           // Save downloaded file to cache.
           self.cache.setCacheFile(


### PR DESCRIPTION
https://github.com/geekaurora/CZHttpFile/issues/42

### Solution

- Only call once in `self.cache.setCacheFile(withUrl:)`  `completeSetCachedItemsDict` closure.