### PR TITLE
[UnitTest] Verify downloaded file returns from disk cache if has been cached.

### DIFF
--- a/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
+++ b/Sources/CZHttpFile/CZHttpFileCache/Core/CZBaseHttpFileCache.swift
@@ -164,7 +164,7 @@ open class CZBaseHttpFileCache<DataType: NSObjectProtocol>: NSObject {
           self.setMemCache(image: image, forKey: cacheKey)
         }
         MainQueueScheduler.async {
-          completion(decodedData)
+           completion(decodedData)
         }
       }
       

--- a/Sources/CZHttpFile/CZHttpFileManager.swift
+++ b/Sources/CZHttpFile/CZHttpFileManager.swift
@@ -54,12 +54,13 @@ public typealias CZHttpFileDownloderCompletion = (_ data: Data?, _ error: Error?
                            priority: Operation.QueuePriority = .normal,
                            progress: HTTPRequestWorker.Progress? = nil,
                            completion: @escaping CZHttpFileDownloderCompletion) {
-        
+  
     cache.getCachedFile(withUrl: url) { [weak self] (data: NSData?) in
       guard let `self` = self else { return }
+      
+      // Load from local disk.
       if CZHttpFileDownloaderConfig.enableLocalCache,
          let data = data as Data? {
-        // Load from local disk.
         MainQueueScheduler.sync {
           completion(data, nil, true)
         }

--- a/Tests/CZHttpFileTests/CZHttpFileManagerTests/CZHttpFileManagerTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileManagerTests/CZHttpFileManagerTests.swift
@@ -110,8 +110,7 @@ final class CZHttpFileManagerTests: XCTestCase {
     // Wait for expectatation.
     waitForExpectatation()
   }
-  
-  
+    
   /// [Written by the previous test] Test read from cache after relaunching App / ColdStart.
   /// It verifies both DiskCache and MemCache.
   ///
@@ -139,7 +138,7 @@ final class CZHttpFileManagerTests: XCTestCase {
     }
     
     waitForExpectatation()
-  }
+  }  
   
   // MARK: - Config
   

--- a/Tests/CZHttpFileTests/CZHttpFileManagerTests/CZHttpFileManagerTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileManagerTests/CZHttpFileManagerTests.swift
@@ -36,8 +36,10 @@ final class CZHttpFileManagerTests: XCTestCase {
   private var czHttpFileManager: CZHttpFileManager!
   
   override func setUp() {
-    czHttpFileManager = CZHttpFileManager()
     executionSuccessCount = 0
+
+    czHttpFileManager = CZHttpFileManager()
+    czHttpFileManager.cache.clearCache()
   }
   
   // MARK: - Download
@@ -56,6 +58,8 @@ final class CZHttpFileManagerTests: XCTestCase {
     CZHTTPManager.stubMockData(dict: mockDataMap)
     
     czHttpFileManager.downloadFile(url: MockData.urlForGet) { data, error, fromCache in
+      XCTAssert(!fromCache, "Result should return from network - not from cache. fromCache = \(fromCache)")
+
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
       expectation.fulfill()

--- a/Tests/CZHttpFileTests/CZHttpFileManagerTests/CZHttpFileManagerTests.swift
+++ b/Tests/CZHttpFileTests/CZHttpFileManagerTests/CZHttpFileManagerTests.swift
@@ -5,7 +5,66 @@ import CZNetworking
 @testable import CZHttpFile
 
 final class CZHttpFileManagerTests: XCTestCase {
-
+  public typealias GetRequestSuccess = (Data?) -> Void
+  
+  private enum Constant {
+    static let timeOut: TimeInterval = 10
+  }
+  private enum MockData {
+    static let urlForGet = URL(string: "https://www.apple.com/newsroom/rss-feed-GET.rss")!
+    static let urlForGetCodable = URL(string: "https://www.apple.com/newsroom/rss-feed-GETCodable.rss")!
+    static let urlForGetDictionaryable = URL(string: "https://www.apple.com/newsroom/rss-feed-GetDictionaryable.rss")!
+    static let urlForGetDictionaryableOneModel = URL(string: "https://www.apple.com/newsroom/rss-feed-GetDictionaryableOneModel.rss")!
+    
+    static let dictionary: [String: AnyHashable] = [
+      "a": "sdlfjas",
+      "c": "sdlksdf",
+      "b": "239823sd",
+      "d": 189298723,
+    ]
+    static let array: [AnyHashable] = [
+      "sdlfjas",
+      "sdlksdf",
+      "239823sd",
+      189298723,
+    ]
+  }
+  
+  static let queueLable = "com.tests.queue"
+  @ThreadSafe
+  private var executionSuccessCount = 0
+  private var czHttpFileManager: CZHttpFileManager!
+  
+  override func setUp() {
+    czHttpFileManager = CZHttpFileManager()
+    executionSuccessCount = 0
+  }
+  
+  // MARK: - Download
+  
+  /**
+   Test downloadFile() method.
+   */
+  func testDownloadFile() {
+    let (waitForExpectatation, expectation) = CZTestUtils.waitWithInterval(Constant.timeOut, testCase: self)
+    
+    // Create mockDataMap.
+    let mockData = CZHTTPJsonSerializer.jsonData(with: MockData.dictionary)!
+    let mockDataMap = [MockData.urlForGet: mockData]
+    
+    // Stub MockData.
+    CZHTTPManager.stubMockData(dict: mockDataMap)
+    
+    czHttpFileManager.downloadFile(url: MockData.urlForGet) { data, error, fromCache in
+      let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
+      XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
+      expectation.fulfill()
+    }
+    
+    // Wait for expectatation.
+    waitForExpectatation()
+  }
+  
   // MARK: - Config
   
   func testConfigMaxSize() {


### PR DESCRIPTION
- Verify cold launch - getCache(): not nil

Ticket: https://github.com/geekaurora/CZHttpFile/issues/45